### PR TITLE
chore(release): 1.0.3 — make-based setup, drop unused anthropic dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,43 @@
-.PHONY: help install dev agent frontend extension clean
+.PHONY: help install install-dev update dev agent frontend extension clean
+
+# Prefer uv (https://github.com/astral-sh/uv) — ~10× faster than pip.
+# Falls back to stdlib venv + pip when uv is not installed.
+HAS_UV := $(shell command -v uv 2>/dev/null)
 
 help:
 	@echo "Flowboard dev commands:"
-	@echo "  make install    - install all deps (agent + frontend)"
-	@echo "  make dev        - run agent + frontend concurrently"
-	@echo "  make agent      - run agent only (FastAPI on :8100)"
-	@echo "  make frontend   - run frontend only (Vite on :5173)"
-	@echo "  make extension  - package extension (unpacked: load from ./extension)"
-	@echo "  make clean      - remove build + cache"
+	@echo "  make install      - install runtime deps (agent + frontend)"
+	@echo "  make install-dev  - install agent with dev extras (ruff, pytest)"
+	@echo "  make update       - upgrade existing deps (agent + frontend)"
+	@echo "  make dev          - hint: run agent + frontend in separate terminals"
+	@echo "  make agent        - run agent only (FastAPI on :8100)"
+	@echo "  make frontend     - run frontend only (Vite on :5173)"
+	@echo "  make extension    - package extension (unpacked: load from ./extension)"
+	@echo "  make clean        - remove build + cache"
 
 install:
+ifdef HAS_UV
+	cd agent && uv venv && uv pip install --python .venv/bin/python -e .
+else
 	cd agent && python -m venv .venv && .venv/bin/pip install -e .
+endif
 	cd frontend && npm install
+
+install-dev:
+ifdef HAS_UV
+	cd agent && uv venv && uv pip install --python .venv/bin/python -e ".[dev]"
+else
+	cd agent && python -m venv .venv && .venv/bin/pip install -e ".[dev]"
+endif
+	cd frontend && npm install
+
+update:
+ifdef HAS_UV
+	cd agent && uv pip install --python .venv/bin/python -U -e .
+else
+	cd agent && .venv/bin/pip install -U -e .
+endif
+	cd frontend && npm update
 
 dev:
 	@echo "Run 'make agent' and 'make frontend' in separate terminals."

--- a/README.md
+++ b/README.md
@@ -325,6 +325,24 @@ matching vocab from the system prompt.
 
 > **Windows:** Use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install). All commands assume a Unix shell.
 
+### One-line setup (optional)
+
+If you have `make` installed, the repo ships shortcut targets that wrap
+Steps 2 + 3:
+
+```bash
+make install        # agent venv + frontend deps (uses uv if available, else pip)
+make install-dev    # same, but adds ruff + pytest extras
+make update         # upgrade agent + frontend deps in place
+make agent          # run FastAPI on :8100
+make frontend       # run Vite on :5175
+```
+
+`uv` is auto-detected (~10× faster installs). Install it once with
+`curl -LsSf https://astral.sh/uv/install.sh | sh`, or skip it and the
+Makefile falls back to stdlib `venv` + `pip`. Step 1 (loading the Chrome
+extension) still has to be done manually.
+
 ### Step 1 — load the Chrome extension
 
 ```bash

--- a/agent/flowboard/config.py
+++ b/agent/flowboard/config.py
@@ -9,7 +9,6 @@ HTTP_PORT = int(os.getenv("FLOWBOARD_HTTP_PORT", "8100"))
 WS_HOST = os.getenv("FLOWBOARD_WS_HOST", "127.0.0.1")
 EXTENSION_WS_PORT = int(os.getenv("FLOWBOARD_EXT_WS_PORT", "9222"))
 
-ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 PLANNER_MODEL = os.getenv("FLOWBOARD_PLANNER_MODEL", "claude-sonnet-4-6")
 # "cli" → always use claude CLI; "mock" → always mock; "auto" → CLI if available,
 # otherwise mock. Default auto.

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "websockets>=12.0",
     "python-multipart>=0.0.9",
     "httpx>=0.27",
-    "anthropic>=0.39",
 ]
 
 [project.optional-dependencies]

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowboard-agent"
-version = "0.0.1"
+version = "1.0.3"
 description = "Flowboard local agent: FastAPI + SQLite + extension bridge"
 requires-python = ">=3.10"
 dependencies = [

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.115
+uvicorn[standard]>=0.30
+sqlmodel>=0.0.22
+pydantic>=2.8
+websockets>=12.0
+python-multipart>=0.0.9
+httpx>=0.27

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flowboard-frontend",
   "private": true,
-  "version": "0.0.1",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Drop unused `anthropic` Python SDK dependency (planner uses local `claude` CLI subprocess; SDK was never imported).
- Remove dead `ANTHROPIC_API_KEY` config var.
- Add `agent/requirements.txt` mirroring runtime deps for pip-only flows.
- Extend `Makefile`: auto-detect `uv` (fallback to stdlib `venv` + `pip`), add `make update` and `make install-dev`.
- Document the `make install` / `make update` shortcut path in README Quickstart.
- Bump agent + frontend to **1.0.3**.

## Why

Existing README referenced `requirements.txt` that didn't exist, and `pyproject.toml` shipped a transitive dep that was never imported. This release ships the consistent install/update story the README already promised.

## Test plan

- [ ] `make install` on a clean venv (with and without `uv` on PATH)
- [ ] `make update` upgrades deps in place without recreating venv
- [ ] `make agent` + `make frontend` boot cleanly
- [ ] `pip install -r agent/requirements.txt` works as the manual fallback

https://claude.ai/code/session_01QtxVP5de4paX8wJL9ZUFHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtxVP5de4paX8wJL9ZUFHe)_