### PR TITLE
chore(release): correct version 1.0.3 → 1.0.2

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowboard-agent"
-version = "1.0.3"
+version = "1.0.2"
 description = "Flowboard local agent: FastAPI + SQLite + extension bridge"
 requires-python = ">=3.10"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flowboard-frontend",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Previous release PR (#1) bumped versions to **1.0.3** but the correct next version after `v1.0.1` is `v1.0.2`.
- Roll back agent + frontend version strings to **1.0.2** to align with the existing remote tag sequence.

## Test plan

- [ ] Confirm `agent/pyproject.toml` and `frontend/package.json` both report `1.0.2`
- [ ] Tag `v1.0.2` will be created after merge

https://claude.ai/code/session_01QtxVP5de4paX8wJL9ZUFHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtxVP5de4paX8wJL9ZUFHe)_